### PR TITLE
Updated corpus to check known words

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     url = __url__,
     download_url = '{0}/tarball/v{1}'.format(__url__, __version__),
     bugtrack_url = __bugtrack_url__,
-    install_requires = [],
+    install_requires = ['nltk>=3.1'],
     packages=find_packages(exclude=['tests']),
     package_data={'spellchecker': ['resources/*']},
     include_package_data = True,

--- a/spellchecker/spellchecker.py
+++ b/spellchecker/spellchecker.py
@@ -14,7 +14,8 @@ entire wordnet dictionary. '''
 from nltk.corpus import wordnet as wn
 from nltk.corpus import stopwords
 stopwords=set(stopwords.words('english'))
-modals = ['can', 'could', 'may', 'might', 'must', 'will', 'would', 'should']
+modals = ['can', 'could', 'may', 'might', 'must', 'will', 'would', 'should', \
+          'shall']
 WORDS = Counter(set(wn.words()).union(stopwords).union(set(modals)))
 
 class SpellChecker(object):

--- a/spellchecker/spellchecker.py
+++ b/spellchecker/spellchecker.py
@@ -106,7 +106,7 @@ class SpellChecker(object):
                 self.known(self.edit_distance_2(word)) or {word})
 
     def known(self, words):
-        ''' The subset of `words` that appear in the dictionary of words
+        ''' The subset of `words` that appear in the corpus of words
 
             Args:
                 words (list): List of words to determine which are in the \

--- a/spellchecker/spellchecker.py
+++ b/spellchecker/spellchecker.py
@@ -9,8 +9,7 @@ import gzip
 import string
 from collections import Counter
 
-''' WORDS corpus includes stopwords, modals and \
-entire wordnet dictionary. '''
+''' WORDS corpus includes stopwords and wordnet from nltk as well as modals'''
 from nltk.corpus import wordnet as wn
 from nltk.corpus import stopwords
 stopwords=set(stopwords.words('english'))

--- a/spellchecker/spellchecker.py
+++ b/spellchecker/spellchecker.py
@@ -9,6 +9,13 @@ import gzip
 import string
 from collections import Counter
 
+''' WORDS corpus includes stopwords, modals and \
+entire wordnet dictionary. '''
+from nltk.corpus import wordnet as wn
+from nltk.corpus import stopwords
+stopwords=set(stopwords.words('english'))
+modals = ['can', 'could', 'may', 'might', 'must', 'will', 'would', 'should']
+WORDS = Counter(set(wn.words()).union(stopwords).union(set(modals)))
 
 class SpellChecker(object):
     ''' The SpellChecker class encapsulates the basics needed to accomplish a
@@ -107,7 +114,7 @@ class SpellChecker(object):
             Returns:
                 set: The set of those words from the input that are in the \
                 corpus '''
-        return set(w for w in words if w in self._word_frequency.dictionary or
+        return set(w for w in words if w in WORDS or
                    not self._check_if_should_check(w))
 
     def unknown(self, words):


### PR DESCRIPTION
This includes two changes to the existing code:
1.  Added a corpus "WORDS" that includes wordnet and stopwords corpuses from nltk as well as a list of modals. 

2.  Used the "WORDS" corpus to check if a word was known for candidate selection. This was achieved by adding this corpus to `def known(self, words):` .
The changes were inspired when the current SpellCheck did not correct the word "teh" to "the". On investigating the issue, I found that the word "teh" existed in `self._word_frequency.dictionary` with a frequency of 6 (indicating that words with spelling errors existed in the corpus being used currently). 
I would love feedback on the suggested changes (approach or design).