### PR TITLE
Allowing the language to be passed a filepath

### DIFF
--- a/spellchecker/spellchecker.py
+++ b/spellchecker/spellchecker.py
@@ -1,5 +1,6 @@
 """ SpellChecker Module; simple, intuitive spell checker based on the post by
     Peter Norvig. See: https://norvig.com/spell-correct.html """
+import os
 import gzip
 import json
 import pkgutil
@@ -62,7 +63,10 @@ class SpellChecker(object):
             if not isinstance(language, Iterable) or isinstance(language, (str, bytes)):
                 language = [language]  # type: ignore
             for lang in language:
-                filename = "resources/{}.json.gz".format(lang.lower())
+                if os.path.exists(lang):
+                    filename = lang
+                else:
+                    filename = "resources/{}.json.gz".format(lang.lower())
                 try:
                     json_open = pkgutil.get_data("spellchecker", filename)
                 except FileNotFoundError:


### PR DESCRIPTION
Allowing the language to be passed a filepath to the language argument file directly - allowing the behaviour to be the same as using the tags such as 'en' etc but from different locations.

By allowing the argument to take in an absolute path, it gives the module flexibility to integrate into projects with rigid data structures, where the languages will be placed in alternative locations.