### PR TITLE
fixed an error in load_file function

### DIFF
--- a/spellchecker/utils.py
+++ b/spellchecker/utils.py
@@ -102,6 +102,7 @@ def load_file(filename: str, encoding: str) -> typing.Generator[KeyT, None, None
     Yields:
         str: The string data from the file read
     """
+    filename = str(filename)
     if filename[-3:].lower() == ".gz":
         with __gzip_read(filename, mode="rt", encoding=encoding) as data:
             yield data


### PR DESCRIPTION
#151 
The line I changed fixed the error for me:
"..\spellchecker\utils.py", line 105, in load_file
if filename[-3:].lower() == ".gz":
~~~~~~~~^^^^^
TypeError: 'WindowsPath' object is not subscriptable