### PR TITLE
added an assertion to prevent a runtime error that was not so descrip…

### DIFF
--- a/spellchecker/utils.py
+++ b/spellchecker/utils.py
@@ -75,6 +75,8 @@ def ensure_unicode(value: KeyT, encoding: str = "utf-8") -> str:
     """
     if isinstance(value, bytes):
         return value.decode(encoding)
+    elif isinstance(value, list):
+        raise TypeError(f"the provided value {value} is a list")
     return value
 
 


### PR DESCRIPTION
runtime error on spellchecker.known:
AttributeError: 'list' object has no attribute 'lower'
I just added an assertion to make sure the error is more descriptive